### PR TITLE
Update README to include reference to homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ and come with no warranty. Use at your own Risk!
 These examples assume you have the `fsoc` command and `jq` installed locally. 
 If you do not, do this:
 ```shell
-brew install fsoc && brew install jq
+brew install cisco-open/tap/fsoc && brew install jq
 ```


### PR DESCRIPTION
If user hasn't run `brew tap cisco-open/tap`, then `brew install fsoc` will fail to find the recipe `fsoc`. Hence, use the canonical full name of the recipe.