### PR TITLE
Geoff suggest01

### DIFF
--- a/example/codex-workflow/objects/codex/workflow/README.md
+++ b/example/codex-workflow/objects/codex/workflow/README.md
@@ -1,0 +1,18 @@
+start stated in the `examples/codex-workflow` folder
+```shell
+$> cd example/codex-workflow
+$> stated
+```
+load the template
+```shell
+> .init -f objects/codex/workflow/workflow.sw.yaml
+```
+view the output of built-in test cases
+```shell
+> .out /test/cases
+{
+  "testConditionIsFunction": "pass",
+  "testConditionTriggers": "pass",
+  "testMeasurementIsProduces": "pass"
+}
+```

--- a/example/codex-workflow/objects/codex/workflow/workflow.sw.yaml
+++ b/example/codex-workflow/objects/codex/workflow/workflow.sw.yaml
@@ -1,0 +1,54 @@
+id: violations-counter
+name: Violations counter
+description: Counts violations events for k8s workflows
+version: 1.0.0
+specVersion: '0.8'
+events:
+  - name: EventReceived
+    type: contracts:cloudevent/platform:event.enriched.v1 #fully qualified reference to the cloudevent
+    kind: consumed
+    dataOnly: true #only the data portion of the event will be passed to this workflow
+    source: platform
+  - name: CreateMeasurement
+    type: contracts:cloudevent/platform:measurement.received.v1
+    kind: produced
+functions:
+  - name: checkType
+    type: expression
+    operation: >
+      type = 'alerting:healthrule.violation' and 'k8s:workflow' in entities.type
+  - name: createMeasurement
+    type: expression
+    operation: >
+        {
+          "entity": $.entities[0],
+          "type": "codex_workflow:healthrule.violation.count",
+          "attributes": {
+            "violation_severity": $.attributes.violation_severity
+          },
+          "measurements": [
+            {
+              "timestamp": $.attributes.event_time,
+              "intValue": $.attributes.'event_details.condition_details.violation_count'
+            }
+          ]
+        }
+states:
+  - name: EventReceived
+    type: event
+    onEvents:
+      - eventRefs:
+          - EventReceived
+        actions:
+          - name: createMeasurement
+            condition: ${ fn:checkType }
+            functionRef: createMeasurement
+            actionDataFilter:
+              toStateData: ${ measurement }
+    stateDataFilter:
+      output: ${ measurement }
+    end:
+      terminate: true
+      produceEvents:
+        - eventRef: CreateMeasurement
+          data: ${ measurement }

--- a/example/codex-workflow/objects/codex/workflow/workflow.sw.yaml
+++ b/example/codex-workflow/objects/codex/workflow/workflow.sw.yaml
@@ -14,25 +14,26 @@ events:
     kind: produced
 functions:
   - name: checkType
-    type: expression
-    operation: >
-      type = 'alerting:healthrule.violation' and 'k8s:workflow' in entities.type
+    type: statedFunction
+    operation: "${function($in){$in.type = 'alerting:healthrule.violation' and 'k8s:workflow' in $in.entities.type}}"
   - name: createMeasurement
-    type: expression
+    type: statedFunction
     operation: >
-        {
-          "entity": $.entities[0],
-          "type": "codex_workflow:healthrule.violation.count",
-          "attributes": {
-            "violation_severity": $.attributes.violation_severity
-          },
-          "measurements": [
-            {
-              "timestamp": $.attributes.event_time,
-              "intValue": $.attributes.'event_details.condition_details.violation_count'
-            }
-          ]
-        }
+        ${function($in){
+          {
+            "entity": $in.entities[0],
+            "type": "codex_workflow:healthrule.violation.count",
+            "attributes": {
+              "violation_severity": $in.attributes.violation_severity
+            },
+            "measurements": [
+              {
+                "timestamp": $in.attributes.event_time,
+                "intValue": $in.attributes.'event_details.condition_details.violation_count'
+              }
+            ]
+          }
+        }}
 states:
   - name: EventReceived
     type: event
@@ -41,10 +42,10 @@ states:
           - EventReceived
         actions:
           - name: createMeasurement
-            condition: ${ fn:checkType }
-            functionRef: createMeasurement
+            condition: /${ functions[name='checkType'].operation }
+            functionRef: /${ functions[name='createMeasurement'].operation }
             actionDataFilter:
-              toStateData: ${ measurement }
+              toStateData: ${ function($in){$in.measurement} }
     stateDataFilter:
       output: ${ measurement }
     end:
@@ -52,3 +53,39 @@ states:
       produceEvents:
         - eventRef: CreateMeasurement
           data: ${ measurement }
+test:
+  in:
+    entities:
+      - type: k8s:workflow
+        id: k8s:deployment:UtS/BYZNO7y7aDUpXqRvHQ
+    timestamp: 1706911250000
+    type: "alerting:healthrule.violation"
+    attributes:
+      violation_severity: CRITICAL
+      event_details.condition_details.violation_count: 2
+      event_time: 1706911260000
+      violation_id: 88JOkQyNP22VbCNaZJoGkA
+      violation_duration: 6900000
+      config_name: K8s Deployment Running vs Desired
+      event_id: xET0tH4lPP6GxkgpN5m8DQ
+      event_details.condition_details.metric_source: sys:derived:infra-agent
+      entity_type: k8s:deployment
+      event_type: "Violation Continues: Critical"
+      violation_status: OPEN
+      violation_start_time: 1706904360000
+  cases:
+    testConditionIsFunction: >
+          /${$type(states[name='EventReceived'].onEvents.actions[name='createMeasurement'].condition)='function'
+              ?'pass'
+              :'fail (not a function)'}
+    testConditionTriggers: >
+      /${(
+               $action := states[name='EventReceived'].onEvents.actions[name='createMeasurement'];
+               $action.condition($$.test.in)?'pass':  'fail (action condition did not trigger on smoke test data)'
+       )}
+    testMeasurementIsProduces: >
+       /${(
+                $action := states[name='EventReceived'].onEvents.actions[name='createMeasurement'];
+                $action.functionRef($$.test.in).measurements[0].timestamp = test.in.attributes.event_time?'pass':'fail (timestamp)'
+        )}
+    

--- a/example/codex-workflow/objects/fmm/extension/extension.yaml
+++ b/example/codex-workflow/objects/fmm/extension/extension.yaml
@@ -1,0 +1,12 @@
+kind: extension
+namespace:
+  name: codex_workflow
+  version: 1
+name: healthrule.violation.extension
+displayName: Health rule violations count extension
+description: Extension that adds a health rule violations count metric to k8s:workflow
+metricTypes:
+  - codex_workflow:healthrule.violation.count
+extends:
+  k8s:
+  - workflow

--- a/example/codex-workflow/objects/fmm/metric/count.yaml
+++ b/example/codex-workflow/objects/fmm/metric/count.yaml
@@ -1,0 +1,16 @@
+namespace:
+  name: codex_workflow
+  version: 1
+kind: metric
+name: healthrule.violation.count
+displayName: Health rule violations
+description: Counts the number of health rule violations
+attributeDefinitions:
+  attributes:
+    violation_severity: string
+category: sum
+contentType: sum
+aggregationTemporality: delta
+isMonotonic: true
+type: long
+unit: '{violations}'

--- a/example/codex-workflow/tests/readme.md
+++ b/example/codex-workflow/tests/readme.md
@@ -1,0 +1,12 @@
+How to run workflow tests:
+1. install Node.js and npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+2. install stated:
+   > npm install -g stated-js
+3. cd into codex workflow folder
+    > cd example/codex-workflow
+4. run stated
+   > stated
+5. execute tests
+   >.init tests/tests.yaml
+6. check results
+    > .out /results

--- a/example/codex-workflow/tests/tests.yaml
+++ b/example/codex-workflow/tests/tests.yaml
@@ -1,0 +1,62 @@
+testFiles:
+  - ${ $import($open('tests/workflow.test.yaml')) }
+results: >-
+  ${ (
+    $appendPath := function($prefix, $path) {
+      $prefix & '/' & $path
+    };
+
+    $compare := function($actual, $expected, $path) {(
+      $actual_keys := $keys($actual);
+      $expected_keys := $keys($expected);
+
+      $extra_keys := $filter($actual_keys, function($key) { $not($key in $expected_keys) }) ~> $map($appendPath($path, ?));
+      $missing_keys := $filter($expected_keys, function($key) { $not($key in $actual_keys) }) ~> $map($appendPath($path, ?));
+
+      $diff := $map($actual_keys, function($key) {
+          $key in $expected_keys ? $findDiff($lookup($actual, $key), $lookup($expected, $key), $appendPath($path, $key))
+      });
+
+      {
+          "missing": $missing_keys ~> $append($diff.missing),
+          "extra": $extra_keys ~> $append($diff.extra),
+          "diff": $diff.diff[]
+      }
+    )};
+
+    $findDiff := function($actual, $expected, $path) {(
+      $actual != $expected ? (
+          $type($actual) != $type($expected) ?
+              {'diff': {'path': $path, 'diff': 'type', 'expected': $type($expected), 'actual': $type($actual) }} :
+              $type($actual) = 'array' ?
+              (
+                  $count($actual) != $count($expected) ?
+                      {'diff': {'path': $path, 'diff': 'count', 'expected': $count($expected), 'actual': $count($actual)}}
+                      : $map($actual, function($item, $i) {
+                          $compare($item, $expected[$i], $path & '[' & $i & ']' )
+                      })~>$reduce($append);
+              ) :
+              $type($actual) = 'object' ? $compare($actual, $expected, $path) :
+              {'diff': {'path': $path, 'diff': 'value', 'expected': $expected, 'actual': $actual}}
+      )
+    )};
+
+    $runTest := function($name, $function, $input, $expected) { (
+      $actual := $eval($function, $input);
+      ($actual != $expected) ? (
+        $errors := $compare($actual, $expected);
+        $errorReport($errors~>|$|{'test': $name}|);
+        {
+          'test': $name,
+          'result': 'failed',
+          'errors': $errors
+        }
+      )
+      : {
+          'test': $name,
+          'result': 'passed'
+        }
+    )};
+
+    testFiles.testCases.tests.($runTest( '[' & %.name & '].[' & $.name & ']', %.function, $.in, $.out))
+  ) }

--- a/example/codex-workflow/tests/workflow.test.yaml
+++ b/example/codex-workflow/tests/workflow.test.yaml
@@ -1,0 +1,75 @@
+workflow: ${ $import($open('objects/codex/workflow/workflow.sw.yaml')) }
+testCases:
+  - name: functions.checkType
+    function: ../../${ workflow.functions[name="checkType"].operation }
+    tests:
+      - name: match
+        in:
+          entities:
+            - type: k8s:workflow
+              id: k8s:deployment:UtS/BYZNO7y7aDUpXqRvHQ
+          timestamp: 1706911250000
+          type: alerting:healthrule.violation
+          attributes:
+            violation_severity: CRITICAL
+            event_details.condition_details.violation_count: 2
+            event_time: 1706911260000
+            violation_id: 88JOkQyNP22VbCNaZJoGkA
+            violation_duration: 6900000
+            config_name: K8s Deployment Running vs Desired
+            event_id: xET0tH4lPP6GxkgpN5m8DQ
+            event_details.condition_details.metric_source: sys:derived:infra-agent
+            entity_type: k8s:deployment
+            event_type: 'Violation Continues: Critical'
+            violation_status: OPEN
+            violation_start_time: 1706904360000
+        out: true
+      - name: event type not matched
+        in:
+          entities:
+            - type: k8s:workload
+              id: nRIoEU8xOVmMOr1bf1z7vA
+          timestamp: 1706911250000
+          type: alerting:healthrule.violation
+        out: false
+      - name: entity type not matched
+        in:
+          entities:
+            - type: k8s:namespace
+              id: nRIoEU8xOVmMOr1bf1z7vA
+          timestamp: 1706911250000
+          type: alerting:healthrule.violation
+        out: false
+  - name: functions.createMeasurement
+    function: ../../${ workflow.functions[name="createMeasurement"].operation }
+    tests:
+      - name: test
+        in:
+          entities:
+            - type: k8s:workflow
+              id: k8s:deployment:UtS/BYZNO7y7aDUpXqRvHQ
+          timestamp: 1706911250000
+          type: alerting:healthrule.violation
+          attributes:
+            violation_severity: CRITICAL
+            event_details.condition_details.violation_count: 2
+            event_time: 1706911260000
+            violation_id: 88JOkQyNP22VbCNaZJoGkA
+            violation_duration: 6900000
+            config_name: K8s Deployment Running vs Desired
+            event_id: xET0tH4lPP6GxkgpN5m8DQ
+            event_details.condition_details.metric_source: sys:derived:infra-agent
+            entity_type: k8s:deployment
+            event_type: 'Violation Continues: Critical'
+            violation_status: OPEN
+            violation_start_time: 1706904360000
+        out:
+          entity:
+            id: k8s:deployment:UtS/BYZNO7y7aDUpXqRvHQ
+            type: k8s:workflow
+          type: 'codex_workflow:healthrule.violation.count'
+          attributes:
+            violation_severity: CRITICAL
+          measurements:
+            - timestamp: 1706911260000
+              intValue: 2


### PR DESCRIPTION
Must use functions in codex. We will not allow bare expression strings. I understand this puts us out of compliance with serverless workflows spec, but that is OK since this spec is not adopted anywhere and has no users. It is more important for us to follow the Stated approach then the serveless workflows spec. However would love us to join that CNCF effort and perhaps try to get into tighter compliance with the spec.